### PR TITLE
Update move payload in client

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -39,16 +39,16 @@ function createPlane() {
 function handleKey(e) {
   switch (e.key) {
   case 'ArrowUp':
-    socket.emit('move', { type: 'up' });
+    socket.emit('move', { command: 'up' });
     break;
   case 'ArrowDown':
-    socket.emit('move', { type: 'down' });
+    socket.emit('move', { command: 'down' });
     break;
   case 'ArrowLeft':
-    socket.emit('move', { type: 'left' });
+    socket.emit('move', { command: 'left' });
     break;
   case 'ArrowRight':
-    socket.emit('move', { type: 'right' });
+    socket.emit('move', { command: 'right' });
     break;
   default:
     break;


### PR DESCRIPTION
## Summary
- send `command` field instead of `type` when emitting move events

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: pytest not found)*