### PR TITLE
Update JS tests to use Node's built-in runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,4 @@ jobs:
       - name: Test Python
         run: python -m unittest discover tests/backend
       - name: Test JS
-        run: node --test tests/frontend/movement.test.js
+        run: npm test

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,0 @@
-module.exports = {
-  testEnvironment: 'jsdom',
-  testMatch: ['**/tests/**/*.test.js']
-};

--- a/package.json
+++ b/package.json
@@ -2,11 +2,10 @@
   "name": "sky-squad-client",
   "version": "1.0.0",
   "scripts": {
-    "test": "jest",
+    "test": "node --test tests/frontend/movement.test.js",
     "lint": "eslint client/main.js"
   },
   "devDependencies": {
-    "jest": "^29.5.0",
     "eslint": "^8.0.0"
   },
   "type": "module"


### PR DESCRIPTION
## Summary
- switch JS tests to use Node's built-in test runner
- remove unused `jest` dependency and config
- align CI to use the `npm test` command

## Testing
- `npm test`
- `python -m unittest discover tests/backend`
