### PR TITLE
Add star spawning and collection

### DIFF
--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -7,7 +7,8 @@ ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
 if ROOT_DIR not in sys.path:
     sys.path.insert(0, ROOT_DIR)
 
-from server.main import register_user
+import server.main as m
+from server.main import register_user, collect_star, stars
 
 class ApiTestCase(unittest.TestCase):
     def test_register(self):
@@ -19,5 +20,12 @@ class ApiTestCase(unittest.TestCase):
         res = register_user(data)
         self.assertEqual(res['status'], 'ok')
 
+    def test_collect_star_increases_score(self):
+        stars.clear()
+        stars.append({'id': 's1', 'x': 0, 'y': 0})
+        start_score = m.score
+        collect_star('s1')
+        self.assertEqual(m.score, start_score + 1)
+        self.assertEqual(len(stars), 0)
 if __name__ == '__main__':
     unittest.main()

--- a/tests/frontend/movement.test.js
+++ b/tests/frontend/movement.test.js
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { computeNewPosition } from '../../client/main.js';
+import { computeNewPosition, isColliding } from '../../client/main.js';
 
 test('computeNewPosition moves up', () => {
   const pos = { x: 0, y: 0 };
   const newPos = computeNewPosition(pos, 'up');
   assert.ok(newPos.y > pos.y);
+});
+
+test('isColliding detects overlap', () => {
+  const p1 = { x: 0, y: 0 };
+  const p2 = { x: 0.1, y: 0.1 };
+  assert.ok(isColliding(p1, p2, 0.5));
 });


### PR DESCRIPTION
## Summary
- implement periodic star spawning and collection logic on the server
- render stars and detect collisions on the client
- extend frontend movement tests with collision detection
- add backend test for collecting stars

## Testing
- `node --test tests/frontend/movement.test.js`
- `python3 -m unittest tests/backend/test_api.py`
