### PR TITLE
Implement local auth and scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,14 @@ Requirements:
 - Docker Compose
 
 Environment variables:
-- `OIDC_CLIENT_ID`
-- `OIDC_CLIENT_SECRET`
-- `OIDC_ISSUER`
+- `SECRET_KEY` (optional)
 
 Run:
 ```bash
 docker-compose up
 ```
 Then open `http://localhost`.
+
+Use the registration form to create an account, then log in to receive a JWT
+token. The game uses this token for authenticated requests.
+

--- a/client/index.html
+++ b/client/index.html
@@ -14,7 +14,8 @@
       <input type="text" id="username" placeholder="Username" required>
       <input type="email" id="email" placeholder="Email" required>
       <input type="password" id="password" placeholder="Password" required>
-      <button type="submit">Register</button>
+      <button id="registerBtn">Register</button>
+      <button id="loginBtn">Login</button>
     </form>
   </div>
   <div id="game" style="display:none;">
@@ -26,3 +27,4 @@
   <script src="main.js"></script>
 </body>
 </html>
+

--- a/client/login.js
+++ b/client/login.js
@@ -1,5 +1,8 @@
 const form = document.getElementById('loginForm');
-form.addEventListener('submit', async (e) => {
+const registerBtn = document.getElementById('registerBtn');
+const loginBtn = document.getElementById('loginBtn');
+
+registerBtn.addEventListener('click', async (e) => {
   e.preventDefault();
   const username = document.getElementById('username').value;
   const email = document.getElementById('email').value;
@@ -10,10 +13,33 @@ form.addEventListener('submit', async (e) => {
     body: JSON.stringify({ username, email, password })
   });
   if (res.ok) {
-    document.getElementById('login').style.display = 'none';
-    document.getElementById('game').style.display = 'block';
-    startGame(username);
+    await loginUser(username, password);
   } else {
     alert('Registration failed');
   }
 });
+
+loginBtn.addEventListener('click', async (e) => {
+  e.preventDefault();
+  const username = document.getElementById('username').value;
+  const password = document.getElementById('password').value;
+  await loginUser(username, password);
+});
+
+async function loginUser(username, password) {
+  const res = await fetch('/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    localStorage.setItem('token', data.token);
+    document.getElementById('login').style.display = 'none';
+    document.getElementById('game').style.display = 'block';
+    startGame(username);
+  } else {
+    alert('Login failed');
+  }
+}
+

--- a/server/main.py
+++ b/server/main.py
@@ -2,8 +2,7 @@ try:
     from fastapi import FastAPI, WebSocket, WebSocketDisconnect, Depends, HTTPException
     from fastapi_socketio import SocketManager
     from pydantic import BaseModel
-    from jose import jwt, JWTError, jwk
-    from authlib.integrations.requests_client import OAuth2Session
+    from jose import jwt, JWTError
     from sqlalchemy import create_engine, Column, Integer, String
     from sqlalchemy.ext.declarative import declarative_base
     from sqlalchemy.orm import sessionmaker, Session
@@ -72,12 +71,6 @@ except Exception:  # fallback for tests
     bcrypt = DummyBcrypt
     jwt = None
     JWTError = Exception
-    jwk = None
-    class OAuth2Session:
-        def __init__(self, *args, **kwargs):
-            pass
-        def fetch_jwk_set(self, issuer):
-            return {'keys': []}
 
 import os
 import uvicorn
@@ -86,9 +79,6 @@ import random
 from uuid import uuid4
 
 SECRET_KEY = os.getenv('SECRET_KEY', 'secret')
-OIDC_CLIENT_ID = os.getenv('OIDC_CLIENT_ID', '')
-OIDC_CLIENT_SECRET = os.getenv('OIDC_CLIENT_SECRET', '')
-OIDC_ISSUER = os.getenv('OIDC_ISSUER', '')
 
 app = FastAPI()
 sm = SocketManager(app=app)
@@ -123,6 +113,11 @@ class RegisterRequest(BaseModel):
     email: str
     password: str
 
+
+class LoginRequest(BaseModel):
+    username: str
+    password: str
+
 def get_db():
     db = SessionLocal()
     try:
@@ -130,47 +125,35 @@ def get_db():
     finally:
         db.close()
 
-def fetch_jwks() -> dict:
-    if jwt is None or jwk is None:
-        return {'keys': []}
-    client = OAuth2Session(client_id=OIDC_CLIENT_ID,
-                           client_secret=OIDC_CLIENT_SECRET)
-    try:
-        return client.fetch_jwk_set(OIDC_ISSUER)
-    except Exception:
-        return {'keys': []}
+def create_token(username: str) -> str:
+    if jwt is None:
+        return username
+    return jwt.encode({'sub': username}, SECRET_KEY, algorithm='HS256')
 
-JWKS = fetch_jwks()
 
 def verify_token(token: str) -> str:
-    if jwt is None or jwk is None:
+    if jwt is None:
         return token
     try:
-        header = jwt.get_unverified_header(token)
-        key_data = next((k for k in JWKS.get('keys', [])
-                         if k.get('kid') == header.get('kid')), None)
-        if not key_data:
-            raise JWTError('Key not found')
-        key = jwk.construct(key_data)
-        payload = jwt.decode(
-            token,
-            key.to_pem().decode('utf-8'),
-            algorithms=[key_data.get('alg', 'RS256')],
-            audience=OIDC_CLIENT_ID,
-            issuer=OIDC_ISSUER,
-        )
+        payload = jwt.decode(token, SECRET_KEY, algorithms=['HS256'])
         return payload.get('sub')
     except Exception as exc:
         raise HTTPException(status_code=401, detail='Invalid token') from exc
 
 @app.post('/register')
-async def register(req: RegisterRequest, authorization: str = '',
-                   db: Session = Depends(get_db)):
-    token = authorization.replace('Bearer ', '') if authorization else ''
-    verify_token(token)
+async def register(req: RegisterRequest, db: Session = Depends(get_db)):
     data = req.dict()
     register_user(data, db)
     return {'status': 'ok'}
+
+
+@app.post('/login')
+async def login(req: LoginRequest, db: Session = Depends(get_db)):
+    user = db.query(User).filter_by(username=req.username).first()
+    if not user or not bcrypt.verify(req.password, user.password):
+        raise HTTPException(status_code=401, detail='Invalid credentials')
+    token = create_token(user.username)
+    return {'token': token}
 
 @app.get('/stats')
 async def get_stats(authorization: str = '', db: Session = Depends(get_db)):
@@ -201,7 +184,7 @@ def collect_star(star_id: str) -> bool:
     star = next((s for s in stars if s['id'] == star_id), None)
     if star:
         stars.remove(star)
-        score += 1
+        score += 10
         return True
     return False
 
@@ -232,7 +215,17 @@ async def websocket_endpoint(socket: WebSocket):
                         pos['x'] += 0.1
                     players[socket] = pos
                 elif data.get('type') == 'collect_star':
-                    collect_star(data.get('starId', ''))
+                    if collect_star(data.get('starId', '')):
+                        username = players[socket].get('username', '')
+                        if username:
+                            try:
+                                db = SessionLocal()
+                                user = db.query(User).filter_by(username=username).first()
+                                if user:
+                                    user.stars += 1
+                                    db.commit()
+                            finally:
+                                db.close()
             state = {
                 'score': score,
                 'players': list(players.values()),

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,4 +5,3 @@ python-jose
 python-multipart
 sqlalchemy
 passlib
-authlib

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -29,7 +29,7 @@ class ApiTestCase(unittest.TestCase):
         stars.append({'id': 's1', 'x': 0, 'y': 0})
         start_score = m.score
         collect_star('s1')
-        self.assertEqual(m.score, start_score + 1)
+        self.assertEqual(m.score, start_score + 10)
         self.assertEqual(len(stars), 0)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add simple JWT login endpoint
- update score for star collections and persist to DB
- implement login/register buttons in the frontend
- adjust unit tests for new scoring logic

## Testing
- `python3 pytest`
- `node jest.js`
