### PR TITLE
Update websocket auth handling

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -11,7 +11,8 @@ let camera;
 
 function startGame(name) {
   username = name;
-  socket = io('/ws');
+  const token = localStorage.getItem('token') || '';
+  socket = io('/ws', { query: { token } });
   socket.on('state', (state) => {
     updateGame(state);
   });

--- a/server/main.py
+++ b/server/main.py
@@ -190,6 +190,15 @@ def collect_star(star_id: str) -> bool:
 
 @app.websocket('/ws')
 async def websocket_endpoint(socket: WebSocket):
+    token = ''
+    if hasattr(socket, 'query_params'):
+        token = socket.query_params.get('token', '')
+    try:
+        verify_token(token)
+    except HTTPException:
+        if hasattr(socket, 'close'):
+            await socket.close(code=403)
+        return
     await sm.connect(socket)
     players[socket] = {'username': '', 'x': 0.0, 'y': 0.0}
     try:


### PR DESCRIPTION
## Notes
- Jest tests pass, but pytest couldn't run because it isn't installed in the environment.

## Summary
- forward stored JWT token when connecting to the websocket
- authenticate websocket connections server‑side and reject invalid tokens

## Testing
- `node jest.js`
- `python -m pytest -q` *(fails: No module named pytest)*