### PR TITLE
Add nginx proxy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ docker-compose up
 ```
 Then open `http://localhost`.
 
+Docker Compose starts an Nginx container for the frontend. It serves the static
+files in `client/` and proxies `/register`, `/login`, `/stats`, and `/ws` to the
+backend service at `http://server:8000` using the config in `client/nginx.conf`.
+
 Use the registration form to create an account, then log in to receive a JWT
 token. The game uses this token for authenticated requests. Tokens are valid for
 one hour by default.

--- a/client/nginx.conf
+++ b/client/nginx.conf
@@ -1,0 +1,30 @@
+events {}
+http {
+  server {
+    listen 80;
+    root /usr/share/nginx/html;
+
+    location / {
+      try_files $uri $uri/ =404;
+    }
+
+    location /register {
+      proxy_pass http://server:8000/register;
+    }
+
+    location /login {
+      proxy_pass http://server:8000/login;
+    }
+
+    location /stats {
+      proxy_pass http://server:8000/stats;
+    }
+
+    location /ws {
+      proxy_pass http://server:8000/ws;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
+  }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,6 @@ services:
     image: nginx:alpine
     volumes:
       - ./client:/usr/share/nginx/html:ro
+      - ./client/nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
       - "80:80"


### PR DESCRIPTION
## Summary
- create `client/nginx.conf` with proxy rules for API endpoints
- mount the new config in `docker-compose.yml`
- document nginx proxy usage in README

## Testing
- `node jest.js`
- `python pytest`