### PR TITLE
Implement OIDC token validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Requirements:
 
 Environment variables:
 - `SECRET_KEY` (optional)
+- `OIDC_ISSUER` - OIDC provider URL
+- `OIDC_CLIENT_ID` - client ID
+- `OIDC_JWKS` - JWKS JSON string
+- `OIDC_REDIRECT_URI` - callback URL
 
 Run:
 ```bash

--- a/docs/design.md
+++ b/docs/design.md
@@ -41,3 +41,10 @@ Sky Squad is a cooperative 2D flight game aimed at children aged 6–12. Players
 ## Assets
 Use free assets from OpenGameArt.org or similar sources. Placeholder images can be used during development with instructions to replace them before release.
 
+## Environment Variables
+- `SECRET_KEY`: secret for local JWT tokens.
+- `OIDC_ISSUER`: URL of the OIDC provider.
+- `OIDC_CLIENT_ID`: client ID for this game.
+- `OIDC_JWKS`: JWKS string containing provider public keys.
+- `OIDC_REDIRECT_URI`: redirect URI registered with the provider.
+

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -5,3 +5,4 @@ python-jose
 python-multipart
 sqlalchemy
 passlib
+authlib

--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -31,5 +31,28 @@ class ApiTestCase(unittest.TestCase):
         collect_star('s1')
         self.assertEqual(m.score, start_score + 10)
         self.assertEqual(len(stars), 0)
+
+    def test_verify_token_valid(self):
+        os.environ['OIDC_JWKS'] = '{"keys":[]}'
+        os.environ['OIDC_ISSUER'] = 'issuer'
+        os.environ['OIDC_CLIENT_ID'] = 'client'
+        import importlib
+        importlib.reload(m)
+        token = m.oidc_jwt.encode({'alg': 'none'},
+                                 {'iss': 'issuer', 'aud': 'client',
+                                  'sub': 'bob'}, None)
+        self.assertEqual(m.verify_token(token), 'bob')
+
+    def test_verify_token_bad_issuer(self):
+        os.environ['OIDC_JWKS'] = '{"keys":[]}'
+        os.environ['OIDC_ISSUER'] = 'issuer'
+        os.environ['OIDC_CLIENT_ID'] = 'client'
+        import importlib
+        importlib.reload(m)
+        token = m.oidc_jwt.encode({'alg': 'none'},
+                                 {'iss': 'other', 'aud': 'client',
+                                  'sub': 'bob'}, None)
+        with self.assertRaises(m.HTTPException):
+            m.verify_token(token)
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- integrate authlib-based OIDC token verification in `server/main.py`
- change registration and login endpoints to redirect to provider
- document new OIDC environment variables
- add unit tests covering token validation

## Testing
- `pytest -q` *(fails: command not found)*