### PR TITLE
Fix game startup after login

### DIFF
--- a/client/main.js
+++ b/client/main.js
@@ -140,6 +140,9 @@ function startGame(name) {
   }
 }
 
+// Expose startGame globally so login.js can invoke it
+window.startGame = startGame;
+
 function initScene() {
   try {
     logEvent('Initializing scene', { canvasExists: !!document.getElementById('gameCanvas') });


### PR DESCRIPTION
## Summary
- expose `startGame` globally so the login module can call it

## Testing
- `pytest -q` *(fails: command not found)*
- `npm test` *(fails: jest-environment-jsdom cannot be found)*