### PR TITLE
Remove duplicate logger

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -459,21 +459,6 @@ players = {}
 score = 0
 stars = []
 star_id_counter = 0
-
-# Configure logger
-logger = logging.getLogger("sky_squad")
-logger.setLevel(logging.INFO)
-handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter(json.dumps({
-    "timestamp": "%(asctime)s",
-    "level": "%(levelname)s",
-    "message": "%(message)s",
-    "module": "%(module)s",
-    "function": "%(funcName)s"
-})))
-logger.addHandler(handler)
-
-
 def generate_star():
     """Generate a new star with random position and value"""
     global stars, star_id_counter


### PR DESCRIPTION
## Summary
- remove secondary logger setup in `server/main.py`

## Testing
- `python3 -m pytest` *(fails: No module named pytest)*
- `npx jest` *(fails: jest-environment-jsdom cannot be found)*