### PR TITLE
Fix async collect_star tests

### DIFF
--- a/tests/backend/test_api.py
+++ b/tests/backend/test_api.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import sys
+import asyncio
 
 # Ensure the server package is importable when tests are run with pytest
 ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..'))
@@ -28,7 +29,7 @@ class ApiTestCase(unittest.TestCase):
         stars.clear()
         stars.append({'id': 's1', 'x': 0, 'y': 0})
         start_score = m.score
-        collect_star('s1')
+        asyncio.run(collect_star('s1'))
         self.assertEqual(m.score, start_score + 10)
         self.assertEqual(len(stars), 0)
 

--- a/tests/backend/test_main.py
+++ b/tests/backend/test_main.py
@@ -5,6 +5,7 @@ import unittest
 import os
 import sys
 import json
+import asyncio
 from unittest.mock import patch, MagicMock, AsyncMock
 
 # Ensure the server package is importable when tests are run with pytest
@@ -67,7 +68,7 @@ class TestMainAPI(unittest.TestCase):
         """Test collecting a non-existent star"""
         m.stars.clear()
         m.score = 0
-        result = m.collect_star('nonexistent')
+        result = asyncio.run(m.collect_star('nonexistent'))
         self.assertFalse(result)
         self.assertEqual(m.score, 0)
     
@@ -85,7 +86,7 @@ class TestMainAPI(unittest.TestCase):
         })
         
         # Collect the star
-        result = m.collect_star(star_id)
+        result = asyncio.run(m.collect_star(star_id))
         
         # Verify results
         self.assertTrue(result)


### PR DESCRIPTION
## Summary
- update backend tests to call async `collect_star` using `asyncio.run`
- update imports accordingly

## Testing
- `python3 -m pytest tests/backend` *(fails: No module named pytest)*