### PR TITLE
Adjust star value generation

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -480,7 +480,8 @@ def generate_star():
     star_id_counter += 1
     
     # Randomly assign value - 10% chance of special star
-    value = 5 if random.random() < 0.1 else 1
+    # Regular stars are worth 10 points; special stars are worth 50
+    value = 50 if random.random() < 0.1 else 10
     
     star = {
         'id': f'star_{star_id_counter}',

--- a/tests/backend/test_main.py
+++ b/tests/backend/test_main.py
@@ -81,7 +81,8 @@ class TestMainAPI(unittest.TestCase):
         m.stars.append({
             'id': star_id,
             'x': 100,
-            'y': 100
+            'y': 100,
+            'value': 10
         })
         
         # Collect the star
@@ -89,7 +90,7 @@ class TestMainAPI(unittest.TestCase):
         
         # Verify results
         self.assertTrue(result)
-        self.assertEqual(m.score, 1)  # Default value is 1
+        self.assertEqual(m.score, 10)  # Default value is 10
         self.assertEqual(len(m.stars), 0)
     
     @patch('server.main.bcrypt')


### PR DESCRIPTION
## Summary
- update `generate_star` to assign 10 points to normal stars and 50 points to special stars
- adjust backend tests for new default star value

## Testing
- `python -m pytest tests/backend` *(fails: No module named pytest)*